### PR TITLE
Add quality report missingness refinements and test coverage

### DIFF
--- a/R/quality_report.R
+++ b/R/quality_report.R
@@ -42,7 +42,16 @@
 #'   instance context when available from the REDCap export.
 #'   `summaries$project$raw_row_count` equals `nrow()` for the records returned
 #'   by the REDCap API. `summaries$project$field_count` is the count of distinct
-#'   standardized metadata field names.
+#'   standardized metadata field names. `summaries$fields$missing_rate` is the
+#'   field-level fraction missing among applicable rows.
+#'   `summaries$forms$missing_rate` and `summaries$project$missing_rate` are
+#'   weighted fractions missing across applicable field-row cells. Applicability
+#'   accounts for form availability, event-form mapping, repeating instrument
+#'   structure, and branching logic. Missingness is only assessed where the raw
+#'   REDCap form status column `<form_name>_complete` is `1`/Unverified or
+#'   `2`/Complete. Status `0`/Incomplete is handled by operational checks and
+#'   does not contribute to missingness, even when REDCap exports checkbox
+#'   choices as `0`.
 #'
 #' @examples
 #' \dontrun{
@@ -579,7 +588,7 @@ get_field_applicable_rows <- function(project, field) {
 
   metadata_row <- get_metadata_row(project, field)
 
-  get_form_applicable_rows(project, metadata_row$form_name) &
+  get_missingness_form_applicable_rows(project, metadata_row$form_name) &
     get_branching_applicable_rows(project, metadata_row$branching_logic)
 }
 
@@ -595,7 +604,7 @@ get_field_applicability <- function(project) {
 
   form_rows <- setNames(
     map(unique(field_metadata$form_name), \(form_name) {
-      get_form_applicable_rows(project, form_name)
+      get_missingness_form_applicable_rows(project, form_name)
     }),
     unique(field_metadata$form_name)
   )
@@ -637,6 +646,30 @@ get_form_applicable_rows <- function(project, form_name) {
         get_event_form_enabled_rows(project, form_name) &
         get_form_available_rows(project, form_name)
     )
+}
+
+get_missingness_form_applicable_rows <- function(project, form_name) {
+  repeated_rows <- get_repeating_instrument_rows(project$data)
+  matching_repeat_rows <- get_matching_repeat_rows(project$data, form_name)
+  nonrepeat_rows <- !repeated_rows
+
+  (
+    matching_repeat_rows |
+      (
+        nonrepeat_rows &
+          get_event_form_enabled_rows(project, form_name)
+      )
+  ) &
+    get_form_completion_assessed_rows(project$data, form_name)
+}
+
+get_form_completion_assessed_rows <- function(data, form_name) {
+  completion_field <- paste0(form_name, "_complete")
+  if (!completion_field %in% names(data)) {
+    return(rep(FALSE, nrow(data)))
+  }
+
+  get_completion_status_value(data[[completion_field]]) %in% c("Unverified", "Complete")
 }
 
 get_repeating_instrument_rows <- function(data) {
@@ -1161,7 +1194,7 @@ get_project_summary <- function(project, findings, field_summary) {
     form_count = n_distinct(project$metadata$form_name),
     event_count = get_project_event_count(project),
     repeating_enabled = get_repeating_enabled(project),
-    mean_missing_rate = if (nrow(field_summary) == 0) NA_real_ else mean(field_summary$missing_rate, na.rm = TRUE),
+    missing_rate = get_weighted_missing_rate(field_summary$missing_count, field_summary$record_count),
     finding_count = nrow(findings)
   )
 
@@ -1212,7 +1245,7 @@ get_form_summary <- function(project, field_summary) {
       form_name = character(),
       field_count = integer(),
       required_field_count = integer(),
-      mean_missing_rate = numeric()
+      missing_rate = numeric()
     ))
   }
 
@@ -1221,9 +1254,18 @@ get_form_summary <- function(project, field_summary) {
     summarise(
       field_count = n(),
       required_field_count = sum(.data$required_field),
-      mean_missing_rate = mean(.data$missing_rate, na.rm = TRUE),
+      missing_rate = get_weighted_missing_rate(.data$missing_count, .data$record_count),
       .groups = "drop"
     )
+}
+
+get_weighted_missing_rate <- function(missing_count, record_count) {
+  denominator <- sum(record_count, na.rm = TRUE)
+  if (denominator == 0) {
+    NA_real_
+  } else {
+    sum(missing_count, na.rm = TRUE) / denominator
+  }
 }
 
 get_record_summary <- function(project, findings) {

--- a/man/build_quality_report.Rd
+++ b/man/build_quality_report.Rd
@@ -36,7 +36,16 @@ A list with \code{findings}, \code{summaries}, and \code{metadata} elements.
 instance context when available from the REDCap export.
 \code{summaries$project$raw_row_count} equals \code{nrow()} for the records returned
 by the REDCap API. \code{summaries$project$field_count} is the count of distinct
-standardized metadata field names.
+standardized metadata field names. \code{summaries$fields$missing_rate} is the
+field-level fraction missing among applicable rows.
+\code{summaries$forms$missing_rate} and \code{summaries$project$missing_rate} are
+weighted fractions missing across applicable field-row cells. Applicability
+accounts for form availability, event-form mapping, repeating instrument
+structure, and branching logic. Missingness is only assessed where the raw
+REDCap form status column \verb{<form_name>_complete} is \code{1}/Unverified or
+\code{2}/Complete. Status \code{0}/Incomplete is handled by operational checks and
+does not contribute to missingness, even when REDCap exports checkbox
+choices as \code{0}.
 }
 \description{
 \code{build_quality_report()} pulls a REDCap project through the API, applies

--- a/tests/testthat/test-quality-report.R
+++ b/tests/testthat/test-quality-report.R
@@ -105,7 +105,7 @@ test_that("build_quality_report returns expected findings and summaries for API 
     notes = c("reviewed", "", "ok", "follow up"),
     symptoms___none = c(1, 1, 0, 0),
     symptoms___fever = c(0, 1, 0, 1),
-    demographics_complete = c(2, 1, 2, NA),
+    demographics_complete = c(2, 1, 2, 1),
     redcap_event_name = rep("baseline_arm_1", 4)
   )
 
@@ -217,7 +217,7 @@ test_that("API field summaries ignore structural missingness from repeating inst
     checks = "missingness"
   )
 
-  expect_equal(report$summaries$project$mean_missing_rate, 0)
+  expect_equal(report$summaries$project$missing_rate, 0)
   expect_equal(nrow(report$findings), 0)
   expect_equal(
     report$summaries$fields |>
@@ -226,6 +226,36 @@ test_that("API field summaries ignore structural missingness from repeating inst
     c(0, 0)
   )
   expect_equal(report$summaries$records$missing_field_count, c(0, 0, 0))
+})
+
+test_that("API project and form missing rates are weighted missing fractions", {
+  redcap_data <- tibble::tibble(
+    record_id = c("1", "2", "3", "4"),
+    gate = c(1, 1, 2, 2),
+    always_value = c(NA, "present", "present", "present"),
+    conditional_value = c(NA, NA, NA, "present"),
+    main_complete = 2
+  )
+
+  metadata <- tibble::tibble(
+    field_name = c("record_id", "gate", "always_value", "conditional_value"),
+    form_name = c("main", "main", "main", "main"),
+    field_type = c("text", "text", "text", "text"),
+    field_label = c("Record ID", "Gate", "Always Value", "Conditional Value"),
+    required_field = c("y", "n", "y", "y"),
+    branching_logic = c(NA, NA, NA, "[gate] = '2'")
+  )
+
+  report <- build_mock_quality_report(
+    data = redcap_data,
+    metadata = metadata,
+    checks = "missingness"
+  )
+
+  expect_false("mean_missing_rate" %in% names(report$summaries$project))
+  expect_false("mean_missing_rate" %in% names(report$summaries$forms))
+  expect_equal(report$summaries$project$missing_rate, 1 / 7)
+  expect_equal(report$summaries$forms$missing_rate, 1 / 7)
 })
 
 test_that("API operational checks ignore structural completion blanks from repeating instruments", {
@@ -410,6 +440,8 @@ test_that("API empty-but-valid input returns stable empty report", {
   expect_equal(report$summaries$project$record_count, 0)
   expect_equal(report$summaries$project$raw_row_count, 0)
   expect_equal(report$summaries$project$field_count, 2)
+  expect_true(is.na(report$summaries$project$missing_rate))
+  expect_true(is.na(report$summaries$forms$missing_rate))
 })
 
 test_that("API nonrepeating form status findings include accessible incomplete rows", {
@@ -449,7 +481,7 @@ test_that("API form applicability excludes forms disabled for a longitudinal eve
     main_value = c("present", "present"),
     lab_value = c(NA, NA),
     main_complete = c(2, 2),
-    labs_complete = c(0, 0)
+    labs_complete = c(1, 0)
   )
 
   metadata <- tibble::tibble(
@@ -494,7 +526,7 @@ test_that("API form applicability excludes Forms Display Logic structural blanks
   redcap_data <- tibble::tibble(
     record_id = c("1", "2"),
     main_value = c("present", "present"),
-    conditional_value = c("answered", NA),
+    conditional_value = c("answered", "structural value"),
     main_complete = c(2, 2),
     conditional_complete = c(2, NA)
   )
@@ -513,15 +545,97 @@ test_that("API form applicability excludes Forms Display Logic structural blanks
     checks = c("missingness", "operational")
   )
 
-  expect_false(any(report$findings$record_id == "2" & report$findings$form_name == "conditional"))
+  expect_false(any(
+    report$findings$check == "missingness" &
+      report$findings$record_id == "2" &
+      report$findings$form_name == "conditional"
+  ))
   expect_equal(
     report$summaries$fields |>
       dplyr::filter(.data$field_name == "conditional_value") |>
       dplyr::pull(.data$record_count),
     1
   )
-  expect_equal(report$summaries$project$mean_missing_rate, 0)
+  expect_equal(report$summaries$project$missing_rate, 0)
   expect_equal(report$summaries$records$missing_field_count, c(0, 0))
+})
+
+test_that("API missingness requires assessed form status", {
+  redcap_data <- tibble::tibble(
+    record_id = as.character(1:8),
+    conditional_value = rep(NA_character_, 8),
+    conditional_complete = c(NA, "", 0, 1, 2, "Incomplete", "Unverified", "Complete")
+  )
+
+  metadata <- tibble::tibble(
+    field_name = c("record_id", "conditional_value"),
+    form_name = c("conditional", "conditional"),
+    field_type = c("text", "text"),
+    field_label = c("Record ID", "Conditional Value"),
+    required_field = c("y", "y")
+  )
+
+  report <- build_mock_quality_report(
+    data = redcap_data,
+    metadata = metadata,
+    checks = "missingness",
+    sparse_threshold = 0.5
+  )
+
+  required_findings <- report$findings |>
+    dplyr::filter(.data$issue == "required_field_missing")
+  sparse_findings <- report$findings |>
+    dplyr::filter(.data$issue == "unexpected_sparse_field")
+
+  expect_equal(required_findings$record_id, c("4", "5", "7", "8"))
+  expect_equal(sparse_findings$field_name, "conditional_value")
+  expect_equal(
+    report$summaries$fields |>
+      dplyr::filter(.data$field_name == "conditional_value") |>
+      dplyr::select("record_count", "missing_count", "missing_rate"),
+    tibble::tibble(record_count = 4L, missing_count = 4L, missing_rate = 1)
+  )
+  expect_equal(report$summaries$project$missing_rate, 0.5)
+  expect_equal(report$summaries$forms$missing_rate, 0.5)
+  expect_equal(report$summaries$records$missing_field_count, c(0, 0, 0, 1, 1, 0, 1, 1))
+})
+
+test_that("API missingness ignores unchecked checkbox exports on incomplete forms", {
+  redcap_data <- tibble::tibble(
+    record_id = c("1", "2"),
+    symptoms___fever = c(0, 0),
+    symptoms___rash = c(0, 0),
+    detail = c(NA, NA),
+    symptoms_complete = c(0, 2)
+  )
+
+  metadata <- tibble::tibble(
+    field_name = c("record_id", "symptoms", "detail"),
+    form_name = c("symptoms", "symptoms", "symptoms"),
+    field_type = c("text", "checkbox", "text"),
+    field_label = c("Record ID", "Symptoms", "Detail"),
+    required_field = c("y", "y", "y"),
+    select_choices_or_calculations = c(NA, "fever, Fever | rash, Rash", NA)
+  )
+
+  report <- build_mock_quality_report(
+    data = redcap_data,
+    metadata = metadata,
+    checks = "missingness"
+  )
+
+  expect_equal(
+    report$findings |>
+      dplyr::filter(.data$issue == "required_field_missing") |>
+      dplyr::pull(.data$record_id),
+    "2"
+  )
+  expect_equal(
+    report$summaries$fields |>
+      dplyr::filter(.data$field_name == "detail") |>
+      dplyr::select("record_count", "missing_count", "missing_rate"),
+    tibble::tibble(record_count = 1L, missing_count = 1L, missing_rate = 1)
+  )
 })
 
 test_that("API field summaries ignore structural missingness between repeating instruments", {
@@ -559,6 +673,46 @@ test_that("API field summaries ignore structural missingness between repeating i
     c(1, 1)
   )
   expect_equal(report$summaries$records$missing_field_count, c(0, 0, 0))
+})
+
+test_that("API repeating missingness requires matching non-missing form status", {
+  redcap_data <- tibble::tibble(
+    record_id = c("1", "1", "1"),
+    redcap_repeat_instrument = c(NA, "repeat_a", "repeat_a"),
+    redcap_repeat_instance = c(NA, 1, 2),
+    main_value = c("present", NA, NA),
+    repeat_a_value = c(NA, NA, NA),
+    main_complete = c(2, NA, NA),
+    repeat_a_complete = c(NA, NA, 1)
+  )
+
+  metadata <- tibble::tibble(
+    field_name = c("record_id", "main_value", "repeat_a_value"),
+    form_name = c("main", "main", "repeat_a"),
+    field_type = c("text", "text", "text"),
+    field_label = c("Record ID", "Main Value", "Repeat A Value"),
+    required_field = c("y", "y", "y")
+  )
+
+  report <- build_mock_quality_report(
+    data = redcap_data,
+    metadata = metadata,
+    checks = "missingness"
+  )
+
+  repeat_findings <- report$findings |>
+    dplyr::filter(
+      .data$issue == "required_field_missing",
+      .data$field_name == "repeat_a_value"
+    )
+
+  expect_equal(repeat_findings$repeat_instance, "2")
+  expect_equal(
+    report$summaries$fields |>
+      dplyr::filter(.data$field_name == "repeat_a_value") |>
+      dplyr::select("record_count", "missing_count", "missing_rate"),
+    tibble::tibble(record_count = 1L, missing_count = 1L, missing_rate = 1)
+  )
 })
 
 test_that("API completion findings preserve form order around repeating forms", {


### PR DESCRIPTION
## Summary

This PR refines REDCap quality report missingness behavior and expands the test suite around current report semantics.

## Changes

- Updates missingness summaries so project and form `missing_rate` values are weighted fractions across applicable field-row cells.
- Gates missingness on assessed REDCap form status:
  - assesses only `1` / `Unverified` and `2` / `Complete`
  - excludes `0` / `Incomplete`, blank, and `NA`
  - leaves operational incomplete-form findings unchanged
- Treats checkbox parent fields as represented by `field___choice` columns for missingness and summaries.
- Handles invalid date strings safely in outlier checks instead of erroring.
- Documents the missingness assumptions in `build_quality_report()` docs.
- Refactors quality-report tests to reduce broad smoke-test coupling and add focused edge-case coverage.
- Trims brittle ggplot internals assertions from record status dashboard tests.

## Validation

- `Rscript -e 'devtools::test()'`
  - 248 passing
- `git diff --check`
  - clean